### PR TITLE
Step 2: Fix port conflict documentation

### DIFF
--- a/CHANGELOG_STEP2.md
+++ b/CHANGELOG_STEP2.md
@@ -1,0 +1,45 @@
+# Step 2 Complete: Port Conflict Fix ✅
+
+**Date:** 2026-01-16
+**Status:** ✅ Documentation Updated
+
+## Summary
+
+Fixed port conflict documentation issue. Homepage was incorrectly documented as using port 8000, but it was already correctly configured on port 3002. TravelSync correctly uses port 8000.
+
+## Situation
+
+- **TravelSync**: Actually using port 8000 ✅ (correct)
+- **Homepage**: Actually using port 3002 ✅ (correct, but README said 8000)
+
+## Changes Made
+
+### Documentation Updates
+- ✅ Updated `README.md` - Changed Homepage port from 8000 → 3002
+- ✅ Updated `docs/reference/infrastructure-summary.md` - Changed Homepage port from 8000 → 3002
+- ✅ Updated `docker/outline/SETUP_GUIDE.md` - Changed Homepage port from 8000 → 3002
+- ✅ Updated `docker/outline/setup-outline.py` - Changed Homepage port from 8000 → 3002
+
+### Configuration Status
+- ✅ Homepage docker-compose.yml: Already correctly configured (3002:3000)
+- ✅ TravelSync: Correctly using port 8000 (as required)
+- ✅ No actual port conflict exists - was a documentation error only
+
+## Verification
+
+```bash
+# Checked actual port usage:
+- TravelSync (documents-to-calendar): 0.0.0.0:8000->8000/tcp ✅
+- Homepage: 0.0.0.0:3002->3000/tcp ✅
+```
+
+## Benefits
+
+1. **Accurate Documentation** - README now reflects actual port usage
+2. **No Conflicts** - TravelSync has exclusive use of port 8000
+3. **Consistency** - All documentation files updated to match reality
+
+## Next Step
+
+Step 3: Add resource limits to Docker services (Jellyfin, Nextcloud, Mattermost, Paperless)
+

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Documentation has been reorganized into a structured format. See [docs/README.md
 | **Mattermost** | 8066 | mattermost.gmojsoski.com | Team communication platform (Slack alternative, PostgreSQL) |
 | **Uptime Kuma** | 3001 | - | Monitoring & alerts |
 | **GoatCounter** | 8088 | analytics.gmojsoski.com | Web analytics |
-| **Homepage** | 8000 | - | Service dashboard |
+| **Homepage** | 3002 | - | Service dashboard |
 | **Portainer** | 9000 | - | Docker management UI |
 | **Gokapi** | 8091 | files.gmojsoski.com | File sharing |
 | **TravelSync** | 8000 | tickets.gmojsoski.com | Travel document processing |

--- a/docker/outline/SETUP_GUIDE.md
+++ b/docker/outline/SETUP_GUIDE.md
@@ -166,7 +166,7 @@ Copy this content:
 - **Cloudflare Tunnel**: 2 replicas for redundancy
 - **Uptime Kuma** (Port 3001): Monitoring & alerts
 - **Portainer** (Port 9000): Docker management UI
-- **Homepage** (Port 8000): Service dashboard
+- **Homepage** (Port 3002): Service dashboard
 
 ### Media & Content
 - **Jellyfin** (Port 8096): Media server (movies, TV, music, books)
@@ -341,6 +341,7 @@ After creating these documents, you can:
 4. **Organize by tags** for better searchability
 
 Happy documenting! 📚
+
 
 
 

--- a/docker/outline/setup-outline.py
+++ b/docker/outline/setup-outline.py
@@ -156,7 +156,7 @@ If a new service breaks things:
 - **Cloudflare Tunnel**: 2 replicas for redundancy
 - **Uptime Kuma** (Port 3001): Monitoring & alerts
 - **Portainer** (Port 9000): Docker management UI
-- **Homepage** (Port 8000): Service dashboard
+- **Homepage** (Port 3002): Service dashboard
 
 ### Media & Content
 - **Jellyfin** (Port 8096): Media server (movies, TV, music, books)

--- a/docs/reference/infrastructure-summary.md
+++ b/docs/reference/infrastructure-summary.md
@@ -49,7 +49,7 @@ The lab consists of two devices:
 | **Mattermost** | 8066 | mattermost.gmojsoski.com | Team communication (PostgreSQL) |
 | **Uptime Kuma** | 3001 | - | Monitoring |
 | **GoatCounter** | 8088 | analytics.gmojsoski.com | Analytics |
-| **Homepage** | 8000 | - | Dashboard |
+| **Homepage** | 3002 | - | Dashboard |
 | **Portainer** | 9000 | - | Docker UI |
 | **Gokapi** | 8091 | files.gmojsoski.com | File sharing |
 | **TravelSync** | 8000 | tickets.gmojsoski.com | Travel docs |


### PR DESCRIPTION
- Fixed incorrect documentation showing Homepage on port 8000
- Homepage is actually on port 3002 (correctly configured)
- TravelSync correctly uses port 8000 exclusively
- Updated all documentation files to reflect actual port usage

Changes:
- README.md: Homepage port 8000 → 3002
- docs/reference/infrastructure-summary.md: Updated Homepage port
- docker/outline/SETUP_GUIDE.md: Updated Homepage port reference
- docker/outline/setup-outline.py: Updated Homepage port reference

Result: No actual port conflict exists - was documentation error only. TravelSync has exclusive use of port 8000 as required.